### PR TITLE
Add difficulty marker

### DIFF
--- a/app/src/androidTest/java/com/github/geohunt/app/ui/components/ChallengeViewTest.kt
+++ b/app/src/androidTest/java/com/github/geohunt/app/ui/components/ChallengeViewTest.kt
@@ -17,9 +17,14 @@ import com.github.geohunt.app.model.database.api.Claim
 import com.github.geohunt.app.model.database.api.Location
 import com.github.geohunt.app.model.database.api.User
 import com.github.geohunt.app.ui.components.challenge.ChallengeView
+import com.github.geohunt.app.ui.components.challenge.difficultyToColor
+import com.github.geohunt.app.ui.theme.difficultyEasy
+import com.github.geohunt.app.ui.theme.difficultyHard
+import com.github.geohunt.app.ui.theme.difficultyMedium
 import com.google.android.gms.tasks.Tasks
 import org.hamcrest.MatcherAssert.assertThat
 import org.hamcrest.Matchers.equalTo
+import org.junit.Assert
 import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
@@ -157,5 +162,15 @@ class ChallengeViewTest {
     fun testChallengeViewWithoutDescription()
     {
         testChallengeView(false)
+    }
+
+    @Test
+    fun testCorrectDifficultyColorIsPicked() {
+        val difficulties = Challenge.Difficulty.values().toList()
+        val colors = listOf(difficultyEasy, difficultyMedium, difficultyHard)
+
+        for ((difficulty, expected) in difficulties.zip(colors)) {
+            Assert.assertEquals(expected, difficultyToColor(difficulty))
+        }
     }
 }

--- a/app/src/main/java/com/github/geohunt/app/ui/components/challenge/BellowImageButton.kt
+++ b/app/src/main/java/com/github/geohunt/app/ui/components/challenge/BellowImageButton.kt
@@ -1,9 +1,9 @@
 package com.github.geohunt.app.ui.components.challenge
 
+import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.layout.*
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material.Button
-import androidx.compose.material.Icon
 import androidx.compose.material.IconButton
 import androidx.compose.material.Text
 import androidx.compose.runtime.*
@@ -23,14 +23,18 @@ import com.github.geohunt.app.model.database.api.Challenge
 import com.github.geohunt.app.model.database.api.User
 import com.github.geohunt.app.ui.FetchComponent
 import com.github.geohunt.app.ui.components.LabelledIcon
-import com.github.geohunt.app.ui.rememberLazyRef
+import com.github.geohunt.app.model.database.api.Challenge.Difficulty.*
+import com.github.geohunt.app.ui.theme.difficultyEasy
+import com.github.geohunt.app.ui.theme.difficultyHard
+import com.github.geohunt.app.ui.theme.difficultyMedium
 import kotlinx.coroutines.launch
 
 @Composable
 internal fun BellowImageButtons(challenge: Challenge, database: Database, user: User) {
     Row(modifier = Modifier
-        .fillMaxWidth()
-        .padding(15.dp, 5.dp)) {
+            .fillMaxWidth()
+            .padding(15.dp, 5.dp),
+        verticalAlignment = Alignment.CenterVertically) {
         val fontSize = 18.sp
         val iconSize = 22.dp
 
@@ -59,6 +63,12 @@ internal fun BellowImageButtons(challenge: Challenge, database: Database, user: 
             tint = Color(R.color.md_theme_light_tertiary),
             contentDescription = "Scores", fontSize = fontSize, iconSize = iconSize
         )
+
+        Spacer(modifier = Modifier
+                .width(22.dp)
+                .weight(0.2f))
+
+        DifficultyCircle(challenge.difficulty)
 
         Spacer(modifier = Modifier.weight(1f))
 
@@ -121,5 +131,18 @@ internal fun LikeButton(challenge: Challenge, database: Database, user: User, fo
                 iconSize = iconSize,
             )
         }
+    }
+}
+
+@Composable
+fun DifficultyCircle(difficulty: Challenge.Difficulty) {
+    Canvas(modifier = Modifier.size(15.dp), onDraw = { drawCircle(difficultyToColor(difficulty)) })
+}
+
+fun difficultyToColor(difficulty: Challenge.Difficulty): Color {
+    return when(difficulty) {
+        EASY -> difficultyEasy
+        MEDIUM -> difficultyMedium
+        HARD -> difficultyHard
     }
 }

--- a/app/src/main/java/com/github/geohunt/app/ui/theme/Color.kt
+++ b/app/src/main/java/com/github/geohunt/app/ui/theme/Color.kt
@@ -8,6 +8,9 @@ val Purple700 = Color(0xFF3700B3)
 val Teal200 = Color(0xFF03DAC5)
 
 val geoHuntRed = Color(0xFFFF3D00)
+val difficultyEasy = Color(0xFF46C403)
+val difficultyMedium = Color(0xFFFF8C00)
+val difficultyHard = Color(0xFFF83838)
 val homeScreenBackground = Color(0xFFE0E0E0)
 val whiteBackground = Color(0xFFFFFFFF)
 


### PR DESCRIPTION
This PR adds a simple, stupid marker of the challenge difficulty to the ChallengeView Composable. 
Not much to say, it was added to give the user a feedback of the selected difficulty after creating a challenge, also gives an intuitive understanding of the difficulty of the challenge to other users.

Closes user story #133 and task #134 